### PR TITLE
Set up `projects` `Namespace` and GSA

### DIFF
--- a/content/config-controller/create-config-controller.md
+++ b/content/config-controller/create-config-controller.md
@@ -32,7 +32,7 @@ source ${WORK_DIR}acm-workshop-variables.sh
 Create the Config Controller's GCP project either at the Folder level or the Organization level:
 {{< tabs groupId="org-level">}}
 {{% tab name="Folder level" %}}
-Create this GCP project at a Folder level:
+Create this resource at a Folder level:
 ```Bash
 gcloud projects create $CONFIG_CONTROLLER_PROJECT_ID \
     --folder $ORG_OR_FOLDER_ID \
@@ -40,7 +40,7 @@ gcloud projects create $CONFIG_CONTROLLER_PROJECT_ID \
 ```
 {{% /tab %}}
 {{% tab name="Org level" %}}
-Alternatively, you could also create this GCP project at the Organization level:
+Alternatively, you could also create this resource at the Organization level:
 ```Bash
 gcloud projects create $CONFIG_CONTROLLER_PROJECT_ID \
     --organization $ORG_OR_FOLDER_ID \
@@ -81,14 +81,6 @@ gcloud anthos config controller create $CONFIG_CONTROLLER_NAME \
 The Config Controller instance provisioning could take around 15-20 min.
 {{% /notice %}}
 
-Check that the Config Controller instance was successfully created:
-```Bash
-gcloud anthos config controller list \
-    --location $CONFIG_CONTROLLER_LOCATION
-gcloud anthos config controller describe $CONFIG_CONTROLLER_NAME \
-    --location $CONFIG_CONTROLLER_LOCATION
-```
-
 ## Get the Config Controller instance credentials
 
 ```Bash
@@ -105,31 +97,8 @@ CONFIG_CONTROLLER_SA="$(kubectl get ConfigConnectorContext \
     -o jsonpath='{.items[0].spec.googleServiceAccount}')"
 ```
 
-Set the `resourcemanager.projectCreator` role either at the Folder level or the Organization level:
-{{< tabs groupId="org-level">}}
-{{% tab name="Folder level" %}}
-Create this GCP project at a Folder level:
+Set the `serviceusage.serviceUsageAdmin` and `iam.serviceAccountAdmin` roles:
 ```Bash
-gcloud resource-manager folders add-iam-policy-binding ${ORG_OR_FOLDER_ID} \
-    --member="serviceAccount:${CONFIG_CONTROLLER_SA}" \
-    --role='roles/resourcemanager.projectCreator'
-```
-{{% /tab %}}
-{{% tab name="Org level" %}}
-Alternatively, you could also create this GCP project at the Organization level:
-```Bash
-gcloud organizations add-iam-policy-binding ${ORG_OR_FOLDER_ID} \
-    --member="serviceAccount:${CONFIG_CONTROLLER_SA}" \
-    --role='roles/resourcemanager.projectCreator'
-```
-{{% /tab %}}
-{{< /tabs >}}
-
-Set the `billing.user`, `serviceusage.serviceUsageAdmin` and `iam.serviceAccountAdmin` roles:
-```Bash
-gcloud beta billing accounts add-iam-policy-binding ${BILLING_ACCOUNT_ID} \
-    --member="serviceAccount:${CONFIG_CONTROLLER_SA}" \
-    --role='roles/billing.user'
 gcloud projects add-iam-policy-binding ${CONFIG_CONTROLLER_PROJECT_ID} \
     --member="serviceAccount:${CONFIG_CONTROLLER_SA}" \
     --role='roles/serviceusage.serviceUsageAdmin'
@@ -145,46 +114,15 @@ List the GCP resources created:
 gcloud projects describe $CONFIG_CONTROLLER_PROJECT_ID
 gcloud anthos config controller list \
     --project $CONFIG_CONTROLLER_PROJECT_ID
-gcloud beta billing accounts get-iam-policy ${BILLING_ACCOUNT_ID} \
-    --filter="bindings.members:${CONFIG_CONTROLLER_SA}" \
-    --flatten="bindings[].members" \
-    --format="table(bindings.role)"
 gcloud projects get-iam-policy $CONFIG_CONTROLLER_PROJECT_ID \
     --filter="bindings.members:${CONFIG_CONTROLLER_SA}" \
     --flatten="bindings[].members" \
     --format="table(bindings.role)"
 ```
-{{< tabs groupId="org-level">}}
-{{% tab name="Folder level" %}}
-```Bash
-gcloud resource-manager folders get-iam-policy $ORG_OR_FOLDER_ID \
-    --filter="bindings.members:${CONFIG_CONTROLLER_SA}" \
-    --flatten="bindings[].members" \
-    --format="table(bindings.role)"
-```
-{{% /tab %}}
-{{% tab name="Org level" %}}
-```Bash
-gcloud organizations get-iam-policy $ORG_OR_FOLDER_ID \
-    --filter="bindings.members:${CONFIG_CONTROLLER_SA}" \
-    --flatten="bindings[].members" \
-    --format="table(bindings.role)"
-```
-{{% /tab %}}
-{{< /tabs >}}
-
 ```Plaintext
 NAME                                                                       LOCATION  STATE
 projects/acm-workshop-463/locations/us-east1/krmApiHosts/configcontroller  us-east1  RUNNING
 ROLE
-roles/resourcemanager.projectCreator
-ROLE
-roles/billing.user
-ROLE
 roles/iam.serviceAccountAdmin
 roles/serviceusage.serviceUsageAdmin
-```
-```Plaintext
-ROLE
-roles/resourcemanager.projectCreator
 ```

--- a/content/config-controller/set-up-projects-management.md
+++ b/content/config-controller/set-up-projects-management.md
@@ -1,0 +1,242 @@
+---
+title: "Set up Projects management"
+weight: 3
+description: "Duration: 10 min | Persona: Org Admin"
+---
+_{{< param description >}}_
+
+Define variables:
+```Bash
+source ${WORK_DIR}acm-workshop-variables.sh
+PROJECTS_NAMESPACE=projects
+echo "export PROJECTS_NAMESPACE=${PROJECTS_NAMESPACE}" >> ${WORK_DIR}acm-workshop-variables.sh
+echo "export PROJECTS_SA_EMAIL=${PROJECTS_NAMESPACE}@${CONFIG_CONTROLLER_PROJECT_ID}.iam.gserviceaccount.com" >> ${WORK_DIR}acm-workshop-variables.sh
+source ${WORK_DIR}acm-workshop-variables.sh
+```
+
+## Define Projects namespace
+
+Create a dedicated folder for this GKE project resources:
+```Bash
+mkdir ~/$WORKSHOP_ORG_DIR_NAME/config-sync/projects
+```
+
+```Bash
+cat <<EOF > ~/$WORKSHOP_ORG_DIR_NAME/config-sync/projects/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${PROJECTS_NAMESPACE}
+EOF
+```
+
+```Bash
+cat <<EOF > ~/$WORKSHOP_ORG_DIR_NAME/config-sync/projects/service-account.yaml
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMServiceAccount
+metadata:
+  name: ${PROJECTS_NAMESPACE}
+  namespace: config-control
+spec:
+  displayName: ${PROJECTS_NAMESPACE}
+EOF
+```
+
+```Bash
+cat <<EOF > ~/$WORKSHOP_ORG_DIR_NAME/config-sync/projects/workload-identity-user.yaml
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPartialPolicy
+metadata:
+  name: ${PROJECTS_NAMESPACE}-sa-wi-user
+  namespace: config-control
+  annotations:
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMServiceAccount/${PROJECTS_NAMESPACE}
+spec:
+  resourceRef:
+    name: ${PROJECTS_NAMESPACE}
+    kind: IAMServiceAccount
+  bindings:
+    - role: roles/iam.workloadIdentityUser
+      members:
+        - member: serviceAccount:${CONFIG_CONTROLLER_PROJECT_ID}.svc.id.goog[cnrm-system/cnrm-controller-manager-${PROJECTS_NAMESPACE}]
+EOF
+```
+
+```Bash
+cat <<EOF > ~/$WORKSHOP_ORG_DIR_NAME/config-sync/projects/config-connector-context.yaml
+apiVersion: core.cnrm.cloud.google.com/v1beta1
+kind: ConfigConnectorContext
+metadata:
+  name: configconnectorcontext.core.cnrm.cloud.google.com
+  namespace: ${PROJECTS_NAMESPACE}
+  annotations:
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMServiceAccount/${PROJECTS_NAMESPACE}
+spec:
+  googleServiceAccount: ${PROJECTS_SA_EMAIL}
+EOF
+```
+
+Set the `resourcemanager.projectCreator` role either at the Folder level or the Organization level:
+{{< tabs groupId="org-level">}}
+{{% tab name="Folder level" %}}
+Create this resource at a Folder level:
+```Bash
+cat <<EOF > ~/$WORKSHOP_ORG_DIR_NAME/config-sync/projects/project-creator.yaml
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-creator-${PROJECTS_NAMESPACE}
+  namespace: config-control
+  annotations:
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMServiceAccount/${PROJECTS_NAMESPACE}
+spec:
+  memberFrom:
+    serviceAccountRef:
+      name: ${PROJECTS_NAMESPACE}
+  role: roles/resourcemanager.projectCreator
+  resourceRef:
+    kind: Folder
+    external: ${ORG_OR_FOLDER_ID}
+EOF
+```
+{{% /tab %}}
+{{% tab name="Org level" %}}
+Alternatively, you could also create this resource at the Organization level:
+```Bash
+cat <<EOF > ~/$WORKSHOP_ORG_DIR_NAME/config-sync/projects/project-creator.yaml
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: project-creator-${PROJECTS_NAMESPACE}
+  namespace: config-control
+  annotations:
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMServiceAccount/${PROJECTS_NAMESPACE}
+spec:
+  memberFrom:
+    serviceAccountRef:
+      name: ${PROJECTS_NAMESPACE}
+  role: roles/resourcemanager.projectCreator
+  resourceRef:
+    kind: Organization
+    external: ${ORG_OR_FOLDER_ID}
+EOF
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+Define the `billing.user` role:
+```Bash
+cat <<EOF > ~/$WORKSHOP_ORG_DIR_NAME/config-sync/projects/billing-user.yaml
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: billing-user-${PROJECTS_NAMESPACE}
+  namespace: config-control
+  annotations:
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMServiceAccount/${PROJECTS_NAMESPACE}
+spec:
+  memberFrom:
+    serviceAccountRef:
+      name: ${PROJECTS_NAMESPACE}
+  role: roles/billing.user
+  resourceRef:
+    kind: BillingAccount
+    external: ${BILLING_ACCOUNT_ID}
+EOF
+```
+
+{{% notice tip %}}
+You could see that we use the annotation `config.kubernetes.io/depends-on`, [since the version 1.11 of Config Management](https://cloud.google.com/anthos-config-management/docs/release-notes#March_24_2022) we could declare [resource dependencies between resource objects](https://cloud.google.com/anthos-config-management/docs/how-to/declare-resource-dependency). KCC already handles dependencies with a retry loop with backoff, which can make things with long reconcile time even longer and generate warnings or errors on these resources. With that annotation we are optimizing these behaviors. We will use this annotation as much as we can throughout this workshop.
+{{% /notice %}}
+
+## Deploy Kubernetes manifests
+
+```Bash
+cd ~/$WORKSHOP_ORG_DIR_NAME/
+git add .
+git commit -m "Set up Projects namespace and service account"
+git push origin main
+```
+
+## Check deployments
+
+{{< mermaid >}}
+graph TD;
+  IAMServiceAccount-->Project
+  IAMPartialPolicy-->IAMServiceAccount
+  ConfigConnectorContext-->IAMServiceAccount
+{{< /mermaid >}}
+
+List the GCP resources created:
+```Bash
+gcloud iam service-accounts describe $PROJECTS_SA_EMAIL \
+    --project $CONFIG_CONTROLLER_PROJECT_ID
+gcloud projects get-iam-policy $CONFIG_CONTROLLER_PROJECT_ID \
+    --filter="bindings.members:${PROJECTS_NAMESPACE}" \
+    --flatten="bindings[].members" \
+    --format="table(bindings.role)"
+gcloud beta billing accounts get-iam-policy ${BILLING_ACCOUNT_ID} \
+    --filter="bindings.members:${PROJECTS_NAMESPACE}" \
+    --flatten="bindings[].members" \
+    --format="table(bindings.role)"
+```
+```Plaintext
+ROLE
+roles/resourcemanager.projectCreator
+ROLE
+roles/billing.user
+```
+
+{{< tabs groupId="org-level">}}
+{{% tab name="Folder level" %}}
+```Bash
+gcloud resource-manager folders get-iam-policy $ORG_OR_FOLDER_ID \
+    --filter="bindings.members:${CONFIG_CONTROLLER_SA}" \
+    --flatten="bindings[].members" \
+    --format="table(bindings.role)"
+```
+{{% /tab %}}
+{{% tab name="Org level" %}}
+```Bash
+gcloud organizations get-iam-policy $ORG_OR_FOLDER_ID \
+    --filter="bindings.members:${CONFIG_CONTROLLER_SA}" \
+    --flatten="bindings[].members" \
+    --format="table(bindings.role)"
+```
+{{% /tab %}}
+{{< /tabs >}}
+```Plaintext
+ROLE
+roles/resourcemanager.projectCreator
+```
+
+List the GitHub runs for the Org configs repository `cd ~/$WORKSHOP_ORG_DIR_NAME && gh run list`:
+```Plaintext
+STATUS  NAME                                           WORKFLOW  BRANCH  EVENT  ID          ELAPSED  AGE
+✓       Set up Projects namespace and service account  ci        main    push   2298085291  1m10s    9m
+✓       Billing API in Config Controller project       ci        main    push   2297919157  1m1s     59m
+✓       Initial commit                                 ci        main    push   2297897719  1m3s     1h
+```
+
+List the Kubernetes resources managed by Config Sync in **Config Controller** for the **Org configs** repository:
+```Bash
+gcloud alpha anthos config sync repo describe \
+    --project $CONFIG_CONTROLLER_PROJECT_ID \
+    --managed-resources all \
+    --sync-name root-sync \
+    --sync-namespace config-management-system
+```
+```Plaintext
+getting 1 RepoSync and RootSync from krmapihost-configcontroller
+┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                                                    managed_resources                                             │
+├────────────────────────────────────┬────────────────────────┬───────────────────────────────────────────────────┬────────────────┤
+│               GROUP                │          KIND          │                        NAME                       │   NAMESPACE    │
+├────────────────────────────────────┼────────────────────────┼───────────────────────────────────────────────────┼────────────────┤
+│                                    │ Namespace              │ projects                                          │                │
+│ iam.cnrm.cloud.google.com          │ IAMPartialPolicy       │ projects-sa-wi-user                               │ config-control │
+│ iam.cnrm.cloud.google.com          │ IAMServiceAccount      │ projects                                          │ config-control │
+│ serviceusage.cnrm.cloud.google.com │ Service                │ cloudbilling.googleapis.com                       │ config-control │
+│ core.cnrm.cloud.google.com         │ ConfigConnectorContext │ configconnectorcontext.core.cnrm.cloud.google.com │ projects       │
+└────────────────────────────────────┴────────────────────────┴───────────────────────────────────────────────────┴────────────────┘
+```

--- a/content/gke-project/create-gke-project.md
+++ b/content/gke-project/create-gke-project.md
@@ -16,7 +16,6 @@ source ${WORK_DIR}acm-workshop-variables.sh
 
 Create a dedicated folder for this GKE project resources:
 ```Bash
-mkdir ~/$WORKSHOP_ORG_DIR_NAME/config-sync/projects
 mkdir ~/$WORKSHOP_ORG_DIR_NAME/config-sync/projects/$GKE_PROJECT_ID
 ```
 
@@ -34,7 +33,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/auto-create-network: "false"
   name: ${GKE_PROJECT_ID}
-  namespace: config-control
+  namespace: ${PROJECTS_NAMESPACE}
 spec:
   name: ${GKE_PROJECT_ID}
   billingAccountRef:
@@ -55,7 +54,7 @@ metadata:
   annotations:
     cnrm.cloud.google.com/auto-create-network: "false"
   name: ${GKE_PROJECT_ID}
-  namespace: config-control
+  namespace: ${PROJECTS_NAMESPACE}
 spec:
   name: ${GKE_PROJECT_ID}
   billingAccountRef:
@@ -76,9 +75,9 @@ apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccount
 metadata:
   name: ${GKE_PROJECT_ID}
-  namespace: config-control
+  namespace: ${PROJECTS_NAMESPACE}
   annotations:
-    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/config-control/Project/${GKE_PROJECT_ID}
+    config.kubernetes.io/depends-on: resourcemanager.cnrm.cloud.google.com/namespaces/${PROJECTS_NAMESPACE}/Project/${GKE_PROJECT_ID}
 spec:
   displayName: ${GKE_PROJECT_ID}
 EOF
@@ -90,13 +89,12 @@ apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPartialPolicy
 metadata:
   name: ${GKE_PROJECT_ID}-sa-wi-user
-  namespace: config-control
+  namespace: ${PROJECTS_NAMESPACE}
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMServiceAccount/${GKE_PROJECT_ID}
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/${PROJECTS_NAMESPACE}/IAMServiceAccount/${GKE_PROJECT_ID}
 spec:
   resourceRef:
     name: ${GKE_PROJECT_ID}
-    apiVersion: iam.cnrm.cloud.google.com/v1beta1
     kind: IAMServiceAccount
   bindings:
     - role: roles/iam.workloadIdentityUser
@@ -117,8 +115,6 @@ kind: Namespace
 metadata:
   annotations:
     cnrm.cloud.google.com/project-id: ${GKE_PROJECT_ID}
-  labels:
-    owner: ${GKE_PROJECT_ID}
   name: ${GKE_PROJECT_ID}
 EOF
 ```
@@ -131,7 +127,7 @@ metadata:
   name: configconnectorcontext.core.cnrm.cloud.google.com
   namespace: ${GKE_PROJECT_ID}
   annotations:
-    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/config-control/IAMServiceAccount/${GKE_PROJECT_ID}
+    config.kubernetes.io/depends-on: iam.cnrm.cloud.google.com/namespaces/${PROJECTS_NAMESPACE}/IAMServiceAccount/${GKE_PROJECT_ID}
 spec:
   googleServiceAccount: ${GKE_PROJECT_SA_EMAIL}
 EOF


### PR DESCRIPTION
The intent of this PR is to avoid any issue with assigning the `billing.user` to the Config Controller's GSA which is not working with Argolis and could be a friction with some customers setup because the GSA is in the format: `...@yakima...`.