### PR TITLE
Better `project-id` annotation management

### DIFF
--- a/content/artifact-registry/create-artifact-registry.md
+++ b/content/artifact-registry/create-artifact-registry.md
@@ -29,6 +29,8 @@ cat <<EOF > ${WORK_DIR}$TENANT_PROJECT_DIR_NAME/artifactregistry.yaml
 apiVersion: artifactregistry.cnrm.cloud.google.com/v1beta1
 kind: ArtifactRegistryRepository
 metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${TENANT_PROJECT_ID}
   name: ${CONTAINER_REGISTRY_NAME}
   namespace: ${TENANT_PROJECT_ID}
 spec:

--- a/content/gke-cluster/create-gke-cluster.md
+++ b/content/gke-cluster/create-gke-cluster.md
@@ -20,7 +20,7 @@ source ${WORK_DIR}acm-workshop-variables.sh
 
 ## Define GKE cluster
 
-Define the GKE cluster with empty node pool:
+Define the [GKE cluster](https://cloud.google.com/config-connector/docs/reference/resource-docs/container/containercluster) with empty node pool:
 ```Bash
 cat <<EOF > ${WORK_DIR}$TENANT_PROJECT_DIR_NAME/gke-cluster.yaml
 apiVersion: container.cnrm.cloud.google.com/v1beta1
@@ -29,6 +29,7 @@ metadata:
   name: ${GKE_NAME}
   namespace: ${TENANT_PROJECT_ID}
   annotations:
+    cnrm.cloud.google.com/project-id: ${TENANT_PROJECT_ID}
     cnrm.cloud.google.com/remove-default-node-pool: "true"
     config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/${TENANT_PROJECT_ID}/ComputeSubnetwork/${GKE_NAME}
   labels:
@@ -83,6 +84,8 @@ cat <<EOF > ${WORK_DIR}$TENANT_PROJECT_DIR_NAME/gke-primary-pool-sa.yaml
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccount
 metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${TENANT_PROJECT_ID}
   name: ${GKE_SA}
   namespace: ${TENANT_PROJECT_ID}
 spec:

--- a/content/gke-cluster/set-up-gke-configs-git-repo.md
+++ b/content/gke-cluster/set-up-gke-configs-git-repo.md
@@ -46,6 +46,7 @@ metadata:
   name: ${GKE_NAME}
   namespace: ${TENANT_PROJECT_ID}
   annotations:
+    cnrm.cloud.google.com/project-id: ${TENANT_PROJECT_ID}
     config.kubernetes.io/depends-on: container.cnrm.cloud.google.com/namespaces/${TENANT_PROJECT_ID}/ContainerCluster/${GKE_NAME}
 spec:
   location: global

--- a/content/host-project/enforce-tenant-projects-policies.md
+++ b/content/host-project/enforce-tenant-projects-policies.md
@@ -7,49 +7,12 @@ tags: ["org-admin", "policies", "security-tips"]
 ![Org Admin](/images/org-admin.png)
 _{{< param description >}}_
 
-In this section you will enforce policies to guarantee that any `Namespaces` in the ConfigController instance defining any Tenant project should have the ProjectId annotation as well as should contain its own `ConfigConnectorContext` object in order to leverage the [namespaced mode of Config Connector](https://cloud.google.com/config-connector/docs/how-to/advanced-install#namespaced-mode).
+In this section you will enforce policies to guarantee that any `Namespaces` in the ConfigController instance defining any Tenant project should contain its own `ConfigConnectorContext` object in order to leverage the [namespaced mode of Config Connector](https://cloud.google.com/config-connector/docs/how-to/advanced-install#namespaced-mode).
 
 Initialize variables:
 ```Bash
 WORK_DIR=~/
 source ${WORK_DIR}acm-workshop-variables.sh
-```
-
-## Define the "Require ProjectId annotation for Namespaces" policy
-
-Define the `namespaces-required-project-id-annotation` `Constraint` based on the `K8sRequiredAnnotations` `ConstraintTemplate` for `Namespaces`:
-```Bash
-cat <<EOF > ${WORK_DIR}$HOST_PROJECT_DIR_NAME/policies/constraints/namespaces-required-project-id-annotation.yaml
-apiVersion: constraints.gatekeeper.sh/v1beta1
-kind: K8sRequiredAnnotations
-metadata:
-  name: namespaces-required-project-id-annotation
-spec:
-  enforcementAction: deny
-  match:
-    kinds:
-    - apiGroups:
-      - ""
-      kinds:
-      - Namespace
-    excludedNamespaces:
-    - cnrm-system
-    - config-control
-    - config-management-monitoring
-    - config-management-system
-    - configconnector-operator-system
-    - default
-    - gatekeeper-system
-    - krmapihosting-monitoring
-    - krmapihosting-system
-    - kube-node-lease
-    - kube-public
-    - kube-system
-    - resource-group-system
-  parameters:
-    annotations:
-    - key: cnrm.cloud.google.com/project-id
-EOF
 ```
 
 ## Define the "Require ConfigConnectorContext for Namespaces" policies
@@ -157,15 +120,4 @@ Wait and re-run this command above until you see `"status": "SYNCED"`. All the `
 List the GitHub runs for the **Host project configs** repository:
 ```Bash
 cd ${WORK_DIR}$HOST_PROJECT_DIR_NAME && gh run list
-```
-
-## Test the policies
-
-If you try to create a `Namespace` without any `ConfigConnectorContext`:
-```Bash
-kubectl create namespace test
-```
-You will get this error confirming that the `Constraints` are in place:
-```Plaintext
-Error from server (Forbidden): admission webhook "validation.gatekeeper.sh" denied the request: [namespaces-required-project-id-annotation] you must provide annotation(s): {"cnrm.cloud.google.com/project-id"}
 ```

--- a/content/ingress-gateway/create-ip-address.md
+++ b/content/ingress-gateway/create-ip-address.md
@@ -19,12 +19,14 @@ source ${WORK_DIR}acm-workshop-variables.sh
 
 ## Define IP address
 
-Define the Ingress Gateway's public static IP address resource:
+Define the Ingress Gateway's [public static IP address](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computeaddress) resource:
 ```Bash
 cat <<EOF > ${WORK_DIR}$TENANT_PROJECT_DIR_NAME/public-ip-address.yaml
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeAddress
 metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${TENANT_PROJECT_ID}
   name: ${INGRESS_GATEWAY_PUBLIC_IP_NAME}
   namespace: ${TENANT_PROJECT_ID}
 spec:

--- a/content/ingress-gateway/set-up-cloud-armor.md
+++ b/content/ingress-gateway/set-up-cloud-armor.md
@@ -21,14 +21,14 @@ source ${WORK_DIR}acm-workshop-variables.sh
 
 ## Define Cloud Armor rules
 
-https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computesecuritypolicy
-
-Define the Ingress Gateway's Cloud Armor rules:
+Define the Ingress Gateway's [Cloud Armor rules](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computesecuritypolicy):
 ```Bash
 cat <<EOF > ${WORK_DIR}$TENANT_PROJECT_DIR_NAME/cloud-armor.yaml
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeSecurityPolicy
 metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${TENANT_PROJECT_ID}
   name: ${SECURITY_POLICY_NAME}
   namespace: ${TENANT_PROJECT_ID}
 spec:
@@ -83,13 +83,15 @@ https://cloud.google.com/armor/docs/rule-tuning#preconfigured_rules
 
 ## Define SSL policy
 
-Not directly related to Cloud Armor, but let's define an SSL policy which will allow us to set an HTTP to HTTPS redirect on the `Ingress`.
+Not directly related to Cloud Armor, but let's define an [SSL policy](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computesslpolicy) which will allow us to set an HTTP to HTTPS redirect on the `Ingress`.
 
 ```Bash
 cat <<EOF > ${WORK_DIR}$TENANT_PROJECT_DIR_NAME/ssl-policy.yaml
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeSSLPolicy
 metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${TENANT_PROJECT_ID}
   name: ${SSL_POLICY_NAME}
   namespace: ${TENANT_PROJECT_ID}
 spec:

--- a/content/networking/set-up-network.md
+++ b/content/networking/set-up-network.md
@@ -19,11 +19,14 @@ source ${WORK_DIR}acm-workshop-variables.sh
 
 ## Define VPC and Subnet
 
+Define the [VPC](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computenetwork):
 ```Bash
 cat <<EOF > ${WORK_DIR}$TENANT_PROJECT_DIR_NAME/vpc.yaml
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeNetwork
 metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${TENANT_PROJECT_ID}
   name: ${GKE_NAME}
   namespace: ${TENANT_PROJECT_ID}
 spec:
@@ -32,6 +35,7 @@ spec:
 EOF
 ```
 
+Define the [Subnet](https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computesubnetwork):
 ```Bash
 cat <<EOF > ${WORK_DIR}$TENANT_PROJECT_DIR_NAME/subnet.yaml
 apiVersion: compute.cnrm.cloud.google.com/v1beta1

--- a/content/onlineboutique/create-memorystore.md
+++ b/content/onlineboutique/create-memorystore.md
@@ -31,10 +31,11 @@ cat <<EOF > ${WORK_DIR}$TENANT_PROJECT_DIR_NAME/$ONLINEBOUTIQUE_NAMESPACE/memory
 apiVersion: redis.cnrm.cloud.google.com/v1beta1
 kind: RedisInstance
 metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${TENANT_PROJECT_ID}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/${TENANT_PROJECT_ID}/ComputeNetwork/${GKE_NAME}
   name: ${REDIS_NAME}
   namespace: ${TENANT_PROJECT_ID}
-  annotations:
-    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/${TENANT_PROJECT_ID}/ComputeNetwork/${GKE_NAME}
 spec:
   authorizedNetworkRef:
     name: ${GKE_NAME}
@@ -53,10 +54,11 @@ cat <<EOF > ${WORK_DIR}$TENANT_PROJECT_DIR_NAME/$ONLINEBOUTIQUE_NAMESPACE/memory
 apiVersion: redis.cnrm.cloud.google.com/v1beta1
 kind: RedisInstance
 metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${TENANT_PROJECT_ID}
+    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/${TENANT_PROJECT_ID}/ComputeNetwork/${GKE_NAME}
   name: ${REDIS_TLS_NAME}
   namespace: ${TENANT_PROJECT_ID}
-  annotations:
-    config.kubernetes.io/depends-on: compute.cnrm.cloud.google.com/namespaces/${TENANT_PROJECT_ID}/ComputeNetwork/${GKE_NAME}
 spec:
   authorizedNetworkRef:
     name: ${GKE_NAME}

--- a/content/onlineboutique/create-spanner.md
+++ b/content/onlineboutique/create-spanner.md
@@ -32,6 +32,8 @@ cat <<EOF > ${WORK_DIR}$TENANT_PROJECT_DIR_NAME/$ONLINEBOUTIQUE_NAMESPACE/spanne
 apiVersion: spanner.cnrm.cloud.google.com/v1beta1
 kind: SpannerInstance
 metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${TENANT_PROJECT_ID}
   name: ${SPANNER_INSTANCE_NAME}
   namespace: ${TENANT_PROJECT_ID}
 spec:
@@ -70,6 +72,8 @@ cat <<EOF > ${WORK_DIR}$TENANT_PROJECT_DIR_NAME/$ONLINEBOUTIQUE_NAMESPACE/spanne
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMServiceAccount
 metadata:
+  annotations:
+    cnrm.cloud.google.com/project-id: ${TENANT_PROJECT_ID}
   name: ${SPANNER_DATABASE_USER_GSA_NAME}
   namespace: ${TENANT_PROJECT_ID}
 spec:

--- a/content/tenant-project/create-tenant-project.md
+++ b/content/tenant-project/create-tenant-project.md
@@ -119,8 +119,6 @@ cat <<EOF > ${WORK_DIR}$HOST_PROJECT_DIR_NAME/projects/$TENANT_PROJECT_ID/namesp
 apiVersion: v1
 kind: Namespace
 metadata:
-  annotations:
-    cnrm.cloud.google.com/project-id: ${TENANT_PROJECT_ID}
   name: ${TENANT_PROJECT_ID}
 EOF
 ```


### PR DESCRIPTION
Better `project-id` annotation management for better performance from Config Connector. It's recommended to remove the `project-id` annotation on the `Namespace`, but rather use this annotation on resources if there is not `projectRef` nor `resourceRef` on them.