### PR TITLE
Add Pod Security Admission (PSA)

### DIFF
--- a/app/content/_index.md
+++ b/app/content/_index.md
@@ -27,7 +27,7 @@ After the workshop, you will be able to:
 - Deploy Infrastructure, Configs and Applications via Kubernetes manifests, via GitOps
 - Define clear roles and responsabilities between Org Admin, Platform Admin and Apps Operator
 - Set up a Managed ASM on GKE with a secure Ingress Gateway behind a HTTPS GCLB and Cloud Armor
-- Deploy sample apps such as Whereami, Online Boutique and Bank of Anthos with security best practices including `NetworkPolicies`, `Sidecars` and `AuthorizationPolicies`.
+- Deploy sample apps such as Whereami, Online Boutique and Bank of Anthos with security best practices including Pod Security Admission (PSA), `NetworkPolicies`, `Sidecars` and `AuthorizationPolicies`.
 - Use external managed databases such as Memorystore (Redis) and Spanner for Online Boutique
 
 With this workshop, here is what you will accomplish, from scratch:

--- a/app/content/bankofanthos/configure-config-sync.md
+++ b/app/content/bankofanthos/configure-config-sync.md
@@ -2,7 +2,7 @@
 title: "Configure Config Sync"
 weight: 3
 description: "Duration: 10 min | Persona: Platform Admin"
-tags: ["asm", "gitops-tips", "platform-admin"]
+tags: ["asm", "gitops-tips", "platform-admin", "security-tips"]
 ---
 ![Platform Admin](/images/platform-admin.png)
 _{{< param description >}}_
@@ -34,9 +34,13 @@ metadata:
   labels:
     name: ${BANKOFANTHOS_NAMESPACE}
     istio-injection: enabled
+    pod-security.kubernetes.io/enforce: baseline
   name: ${BANKOFANTHOS_NAMESPACE}
 EOF
 ```
+{{% notice note %}}
+In addition to the `istio-injection` to include this `Namespace` into our Service Mesh, we are also adding the `pod-security.kubernetes.io/enforce` label as the `baseline` [Pod Security Standards policy](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
+{{% /notice %}}
 
 ## Create GitHub repository
 

--- a/app/content/ingress-gateway/deploy-ingress-gateway.md
+++ b/app/content/ingress-gateway/deploy-ingress-gateway.md
@@ -33,9 +33,13 @@ metadata:
   labels:
     name: ${INGRESS_GATEWAY_NAMESPACE}
     istio-injection: enabled
+    pod-security.kubernetes.io/enforce: restricted
   name: ${INGRESS_GATEWAY_NAMESPACE}
 EOF
 ```
+{{% notice note %}}
+In addition to the `istio-injection` to include this `Namespace` into our Service Mesh, we are also adding the `pod-security.kubernetes.io/enforce` label as the `restricted` [Pod Security Standards policy](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
+{{% /notice %}}
 
 ## Define Deployment
 
@@ -77,7 +81,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-            - all
+            - ALL
           privileged: false
           readOnlyRootFilesystem: true
       securityContext:
@@ -85,6 +89,8 @@ spec:
         runAsGroup: 1337
         runAsNonRoot: true
         runAsUser: 1337
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: ${INGRESS_GATEWAY_NAME}
 EOF
 ```

--- a/app/content/onlineboutique/configure-config-sync.md
+++ b/app/content/onlineboutique/configure-config-sync.md
@@ -2,7 +2,7 @@
 title: "Configure Config Sync"
 weight: 4
 description: "Duration: 5 min | Persona: Platform Admin"
-tags: ["asm", "gitops-tips", "platform-admin"]
+tags: ["asm", "gitops-tips", "platform-admin", "security-tips"]
 ---
 ![Platform Admin](/images/platform-admin.png)
 _{{< param description >}}_
@@ -31,9 +31,13 @@ metadata:
   labels:
     name: ${ONLINEBOUTIQUE_NAMESPACE}
     istio-injection: enabled
+    pod-security.kubernetes.io/enforce: restricted
   name: ${ONLINEBOUTIQUE_NAMESPACE}
 EOF
 ```
+{{% notice note %}}
+In addition to the `istio-injection` to include this `Namespace` into our Service Mesh, we are also adding the `pod-security.kubernetes.io/enforce` label as the `restricted` [Pod Security Standards policy](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
+{{% /notice %}}
 
 ## Allo Config Sync to sync Istio resources
 

--- a/app/content/overview/agenda.md
+++ b/app/content/overview/agenda.md
@@ -23,7 +23,7 @@ tags: ["apps-operator", "org-admin", "platform-admin"]
     1. As Platform Admin, create GKE cluster in Tenant project
     1. As Org Admin, allow Fleet for Tenant project
     1. As Platform Admin, set up GKE configs's Git repo in Tenant project
-    1. As Platform Admin, enforce policies for `NetworkPolicies`
+    1. As Platform Admin, enforce Kubernetes policies with Pod Security Admission (PSA) and `NetworkPolicies`
     1. As Platform Admin, set up `NetworkPolicies` logging in GKE cluster
 1. Artifact Registry
     1. As Org Admin, allow Artifact Registry for Tenant project

--- a/app/content/whereami/configure-config-sync.md
+++ b/app/content/whereami/configure-config-sync.md
@@ -2,7 +2,7 @@
 title: "Configure Config Sync"
 weight: 3
 description: "Duration: 10 min | Persona: Platform Admin"
-tags: ["asm", "gitops-tips", "platform-admin"]
+tags: ["asm", "gitops-tips", "platform-admin", "security-tips"]
 ---
 ![Platform Admin](/images/platform-admin.png)
 _{{< param description >}}_
@@ -34,9 +34,13 @@ metadata:
   labels:
     name: ${WHEREAMI_NAMESPACE}
     istio-injection: enabled
+    pod-security.kubernetes.io/enforce: baseline
   name: ${WHEREAMI_NAMESPACE}
 EOF
 ```
+{{% notice note %}}
+In addition to the `istio-injection` to include this `Namespace` into our Service Mesh, we are also adding the `pod-security.kubernetes.io/enforce` label as the `baseline` [Pod Security Standards policy](https://kubernetes.io/docs/concepts/security/pod-security-standards/).
+{{% /notice %}}
 
 ## Create GitHub repository
 


### PR DESCRIPTION
Add Pod Security Admission (PSA):
- https://kubernetes.io/docs/concepts/security/pod-security-admission/
- https://kubernetes.io/docs/concepts/security/pod-security-standards/

`baseline` for `whereami` and `bankofanthos` + `restricted` for `asm-ingress` and `onlineboutique`.

Also, add the associate Gatekeeper/PoCo policy.