### PR TITLE
Use ooo namespace's name `kubernetes.io/metadata.name`

### DIFF
--- a/app/content/bankofanthos/configure-config-sync.md
+++ b/app/content/bankofanthos/configure-config-sync.md
@@ -32,7 +32,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    name: ${BANKOFANTHOS_NAMESPACE}
     istio-injection: enabled
     pod-security.kubernetes.io/enforce: baseline
   name: ${BANKOFANTHOS_NAMESPACE}

--- a/app/content/bankofanthos/deploy-network-policies.md
+++ b/app/content/bankofanthos/deploy-network-policies.md
@@ -132,7 +132,7 @@ spec:
           app: loadgenerator
     - namespaceSelector:
         matchLabels:
-          name: ${INGRESS_GATEWAY_NAMESPACE}
+          kubernetes.io/metadata.name: ${INGRESS_GATEWAY_NAMESPACE}
       podSelector:
         matchLabels:
           app: ${INGRESS_GATEWAY_NAME}

--- a/app/content/gke-cluster/enforce-kubernetes-policies.md
+++ b/app/content/gke-cluster/enforce-kubernetes-policies.md
@@ -65,45 +65,7 @@ As of now, only the `asm-ingress` and `onlineboutique` namespaces support `restr
 
 ### Require labels for Namespaces and Pods
 
-As a best practice and in order to get the `NetworkPolicies` working in this workshop, we need to guarantee that any `Namespaces` have a label `name` and `Pods` have a label `app`.
-
-Define the `namespaces-required-name-label` `Constraint` based on the [`K8sRequiredLabels`](https://cloud.google.com/anthos-config-management/docs/reference/constraint-template-library#k8srequiredlabels) `ConstraintTemplate` for `Namespaces`:
-```Bash
-cat <<EOF > ${WORK_DIR}$GKE_CONFIGS_DIR_NAME/policies/constraints/namespaces-required-name-label.yaml
-apiVersion: constraints.gatekeeper.sh/v1beta1
-kind: K8sRequiredLabels
-metadata:
-  name: namespaces-required-name-label
-  annotations:
-    policycontroller.gke.io/constraintData: |
-      "{
-        description: 'Requires Namespaces to have the "name" label in order to leverage the namespaceSelector feature of NetworkPolicies.',
-        remediation: 'Any Namespaces should have the "name" label.'
-      }"
-spec:
-  enforcementAction: deny
-  match:
-    kinds:
-    - apiGroups:
-      - ""
-      kinds:
-      - Namespace
-    excludedNamespaces:
-    - config-management-monitoring
-    - config-management-system
-    - default
-    - gatekeeper-system
-    - istio-system
-    - kube-node-lease
-    - kube-public
-    - kube-system
-    - resource-group-system
-    - poco-trial
-  parameters:
-    labels:
-    - key: name
-EOF
-```
+As a best practice and in order to get the `NetworkPolicies` working in this workshop, we need to guarantee that any `Pods` have a label `app`.
 
 Define the `pods-required-app-label` `Constraint` based on the [`K8sRequiredLabels`](https://cloud.google.com/anthos-config-management/docs/reference/constraint-template-library#k8srequiredlabels) `ConstraintTemplate` for `Pods`:
 ```Bash
@@ -141,6 +103,9 @@ spec:
     - key: app
 EOF
 ```
+{{% notice note %}}
+Complementary to this, on `Namespaces` the [`kubernetes.io/metadata.name` label](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#automatic-labelling) automatically set by Kubernetes 1.22+ will be leveraged.
+{{% /notice %}}
 
 ### Require NetworkPolicies in Namespaces
 

--- a/app/content/ingress-gateway/deploy-ingress-gateway.md
+++ b/app/content/ingress-gateway/deploy-ingress-gateway.md
@@ -31,7 +31,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    name: ${INGRESS_GATEWAY_NAMESPACE}
     istio-injection: enabled
     pod-security.kubernetes.io/enforce: restricted
   name: ${INGRESS_GATEWAY_NAMESPACE}

--- a/app/content/onlineboutique/configure-config-sync.md
+++ b/app/content/onlineboutique/configure-config-sync.md
@@ -29,7 +29,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    name: ${ONLINEBOUTIQUE_NAMESPACE}
     istio-injection: enabled
     pod-security.kubernetes.io/enforce: restricted
   name: ${ONLINEBOUTIQUE_NAMESPACE}

--- a/app/content/whereami/configure-config-sync.md
+++ b/app/content/whereami/configure-config-sync.md
@@ -32,7 +32,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    name: ${WHEREAMI_NAMESPACE}
     istio-injection: enabled
     pod-security.kubernetes.io/enforce: baseline
   name: ${WHEREAMI_NAMESPACE}

--- a/app/content/whereami/deploy-network-policies.md
+++ b/app/content/whereami/deploy-network-policies.md
@@ -69,7 +69,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          name: ${INGRESS_GATEWAY_NAMESPACE}
+          kubernetes.io/metadata.name: ${INGRESS_GATEWAY_NAMESPACE}
       podSelector:
         matchLabels:
           app: ${INGRESS_GATEWAY_NAME}


### PR DESCRIPTION
Use ooo namespace's name `kubernetes.io/metadata.name`:
- https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-metadata-name
- https://kubernetes.io/docs/concepts/services-networking/network-policies/#targeting-a-namespace-by-its-name